### PR TITLE
[GITISSUE-79] add HTTPS middleware, Swagger UI customization, and deployment workflow

### DIFF
--- a/.env
+++ b/.env
@@ -15,3 +15,7 @@ LOG_FILE=/var/log/myapp.log
 
 API_KEY=odagenius
 JWT_SECRET_KEY=betweenearthandheaveniamthechosenone
+
+SWAGGER_URL=http://localhost:8080/swagger/doc.json
+ALLOWED_ORIGINS=*
+ENVIRONMENT=development

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,19 +83,3 @@ jobs:
           context: .
           push: true
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/myanimeapi:latest
-
-#  deploy:
-#    name: Deploy to Server
-#    runs-on: ubuntu-latest
-#    needs: [docker]
-#    steps:
-#      - name: Deploy to server
-#        uses: appleboy/ssh-action@master
-#        with:
-#          host: ${{ secrets.SSH_HOST }}
-#          username: ${{ secrets.SSH_USERNAME }}
-#          key: ${{ secrets.SSH_PRIVATE_KEY }}
-#          script: |
-#            docker pull ${{ secrets.DOCKER_HUB_USERNAME }}/myanimeapi:latest
-#            docker-compose down
-#            docker-compose up -d

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,68 @@
+name: Deploy to Render
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.23'
+
+      - name: Run tests
+        run: go test -v ./...
+
+  deploy:
+    if: github.ref == 'refs/heads/main' # Only run on main branch
+    needs: test # Wait for tests to pass
+    runs-on: ubuntu-latest
+    environment: production # Reference the production environment
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.23'
+
+      - name: Install Docker
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y docker.io
+          sudo systemctl start docker
+          sudo systemctl enable docker
+
+      - name: Build Docker image
+        run: docker build -t myanimeapi .
+
+      - name: Log in to Render
+        run: |
+          echo "${{ secrets.RENDER_API_KEY }}" | docker login -u "${{ secrets.RENDER_USERNAME }}" --password-stdin registry.render.com
+
+      - name: Push Docker image to Render
+        run: |
+          docker tag myanimeapi registry.render.com/my-render-service/my-anime-api
+          docker push registry.render.com/my-render-service/my-anime-api
+
+      - name: Deploy to Render
+        run: |
+          curl -X POST \
+            -H "Authorization: Bearer ${{ secrets.RENDER_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "serviceId": "${{ secrets.RENDER_SERVICE_ID }}",
+              "image": "registry.render.com/my-render-service/my-anime-api"
+            }' \
+            https://api.render.com/v1/services/${{ secrets.RENDER_SERVICE_ID }}/deploys

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 
 # Go workspace file
 go.work
+.vercel

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ WORKDIR /root/
 # Copy the Pre-built binary file from the previous stage
 COPY --from=builder /app/main .
 
+# Copy the Swagger documentation
+COPY --from=builder /app/cmd/docs ./cmd/docs
+
 # Copy the .env file
 COPY .env .
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,6 +29,7 @@ import (
 	"myanimeapi/internal/routes"
 	"myanimeapi/pkg/database"
 	myhandlers "myanimeapi/pkg/handlers" // Alias for your custom handlers package
+	"myanimeapi/pkg/middleware"
 
 	gorillahandlers "github.com/gorilla/handlers" // Alias for Gorilla's handlers package
 	"github.com/gorilla/mux"
@@ -92,14 +93,25 @@ func main() {
 	// Create a new router
 	router := mux.NewRouter()
 
+	// Determine environment
+	env := os.Getenv("ENVIRONMENT")
+	if env == "production" {
+		log.Println("Running in production mode")
+
+		// Apply HTTPS redirection middleware
+		router.Use(middleware.RedirectToHTTPS)
+	}
+
+	// Serve Swagger UI
+	swaggerURL := os.Getenv("SWAGGER_URL")
 	// Register all routes
-	swaggerURL := "http://localhost:8080/swagger/doc.json" // or fetch from config
 	routes.RegisterRoutes(router, swaggerURL, animeHandler, userHandler, reviewHandler, authHandler)
 	log.Println("Routes registered successfully")
 
 	// Configure CORS
+	allowedOrigins := os.Getenv("ALLOWED_ORIGINS")
 	corsHandler := gorillahandlers.CORS(
-		gorillahandlers.AllowedOrigins([]string{"*"}), // Allow all origins
+		gorillahandlers.AllowedOrigins([]string{allowedOrigins}),
 		gorillahandlers.AllowedMethods([]string{"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"}),
 		gorillahandlers.AllowedHeaders([]string{"Content-Type", "Authorization"}),
 	)

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -77,6 +77,18 @@ func RegisterRoutes(router *mux.Router, swaggerURL string, animeHandler *handler
 	// Register Swagger documentation
 	router.PathPrefix("/swagger/").Handler(httpSwagger.Handler(
 		httpSwagger.URL(swaggerURL), // Path to swagger.json
+		httpSwagger.UIConfig(map[string]string{
+			"theme": "swagger-ui-dark.css", // Use the dark theme
+			"title": "MyAnimeAPI Documentation",
+			/*			"customStyle": `
+			    	.topbar-wrapper img {
+			        	content: url('https://example.com/logo.png');
+			        	width: 100px;
+			        	height: auto;
+			    	}
+				`,*/ // it will be generated later
+			//"customFavicon": "https://example.com/favicon.ico", // Custom favicon(it will be generated later)
+		}),
 	))
 	log.Println("Swagger documentation registered")
 }

--- a/pkg/middleware/https_middleware.go
+++ b/pkg/middleware/https_middleware.go
@@ -1,0 +1,29 @@
+// pkg/middleware/https_middleware.go
+// pkg/middleware/https_middleware.go
+// Package middleware provides HTTP middleware functions for the MyAnimeAPI application.
+// This file contains middleware for enforcing HTTPS connections.
+package middleware
+
+import "net/http"
+
+// RedirectToHTTPS is a middleware that redirects HTTP requests to HTTPS.
+// It checks the "X-Forwarded-Proto" header to determine if the request is already using HTTPS.
+// If the request is not using HTTPS, it redirects the client to the HTTPS version of the URL.
+//
+// Example:
+//
+//		Usage in a router:
+//	router := http.NewServeMux()
+//	router.HandleFunc("/", myHandler)
+//	http.ListenAndServe(":80", middleware.RedirectToHTTPS(router))
+//
+//	 	When a client accesses "http://example.com", they will be redirected to "https://example.com".
+func RedirectToHTTPS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Forwarded-Proto") != "https" {
+			http.Redirect(w, r, "https://"+r.Host+r.RequestURI, http.StatusMovedPermanently)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}


### PR DESCRIPTION

- Added HTTPS redirection middleware to enforce secure connections in production.
- Customized Swagger UI with dark theme and branding options (logo and favicon to be added later).
- Updated `.env` to include `SWAGGER_URL`, `ALLOWED_ORIGINS`, and `ENVIRONMENT` variables.
- Added a new GitHub Actions workflow (`deploy.yml`) for deploying to Render.
- Updated Dockerfile to include Swagger documentation in the final image.
- Modified `cmd/main.go` to handle environment-specific configurations (e.g., HTTPS redirection, CORS).
- Updated `.gitignore` to exclude `.vercel` directory.
- Removed commented-out deployment steps from `ci.yml`.

Issue: #79 Add deployment to render/vercel