### PR TITLE
fix(ci): upgrade sonarqube-scan-action to v8.1.0 (CVE-2025-59844)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -410,7 +410,7 @@ jobs:
         env:
           HAS_TOKEN: ${{ secrets.SONAR_TOKEN != '' }}
         if: env.HAS_TOKEN == 'true'
-        uses: SonarSource/sonarqube-scan-action@v5.3.1
+        uses: SonarSource/sonarqube-scan-action@v8.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary

- Previous fix (PR #154) upgraded `sonarqube-scan-action` to v5.3.1, which only addressed **CVE-2025-58178** (affects <= 5.3.0).
- **CVE-2025-59844** (argument injection via unsanitized inputs) affects **< 6.0.0** — v5.3.1 was still vulnerable.
- Upgraded to **v8.1.0** (current latest stable), which covers both CVEs.

## CVE breakdown

| CVE | Affected range | v5.3.1 | v8.1.0 |
|-----|---------------|--------|--------|
| CVE-2025-58178 | >= 4.0.0, <= 5.3.0 | ✅ safe | ✅ safe |
| CVE-2025-59844 | >= 4.0.0, < 6.0.0 | ❌ vulnerable | ✅ safe |

## Test plan

- [x] Pre-push hook passed (lint + vet + unit tests with race detection)
- [x] Single occurrence updated in `.github/workflows/pr.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Changes Analysis

### File Type Summary
- **YAML**: 1 files
- **Documentation**: 1 files

### Detailed Changes

#### YAML Files
- .github/workflows/pr.yml

#### Documentation Files
- CHANGELOG.md

### Git Statistics

