### PR TITLE
fix(security): use parseID helper + CodeQL config for gqlgen-managed file

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,8 @@
+name: "myanimeapi CodeQL configuration"
+
+# Exclude fully auto-generated code from CodeQL analysis.
+# schema.resolvers.go is partially managed by gqlgen — resolver bodies are
+# user-written and use the parseID() helper (safe strconv.Atoi conversion).
+# The generated/ directory contains only tool-output and should not be scanned.
+paths-ignore:
+  - "api/adapters/graphql/generated/**"

--- a/api/adapters/graphql/schema.resolvers.go
+++ b/api/adapters/graphql/schema.resolvers.go
@@ -71,11 +71,11 @@ func (r *mutationResolver) CreateAnime(ctx context.Context, title string, descri
 
 // DeleteAnime is the resolver for the deleteAnime field.
 func (r *mutationResolver) DeleteAnime(ctx context.Context, id string) (bool, error) {
-	uid, err := strconv.Atoi(id)
-	if err != nil || uid <= 0 {
+	uid, err := parseID(id)
+	if err != nil {
 		return false, fmt.Errorf("invalid anime ID: %s", id)
 	}
-	if err := r.AnimeService.DeleteAnime(ctx, uint(uid)); err != nil {
+	if err := r.AnimeService.DeleteAnime(ctx, uid); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -83,11 +83,11 @@ func (r *mutationResolver) DeleteAnime(ctx context.Context, id string) (bool, er
 
 // Anime is the resolver for the anime field.
 func (r *queryResolver) Anime(ctx context.Context, id string) (*model.Anime, error) {
-	uid, err := strconv.Atoi(id)
-	if err != nil || uid <= 0 {
+	uid, err := parseID(id)
+	if err != nil {
 		return nil, fmt.Errorf("invalid anime ID: %s", id)
 	}
-	anime, err := r.AnimeService.GetAnimeByID(ctx, uint(uid))
+	anime, err := r.AnimeService.GetAnimeByID(ctx, uid)
 	if err != nil {
 		return nil, err
 	}
@@ -185,11 +185,11 @@ func (r *queryResolver) AnimesByTitle(ctx context.Context, title string, page *i
 
 // Genre is the resolver for the genre field.
 func (r *queryResolver) Genre(ctx context.Context, id string) (*model.Genre, error) {
-	uid, err := strconv.Atoi(id)
-	if err != nil || uid <= 0 {
+	uid, err := parseID(id)
+	if err != nil {
 		return nil, fmt.Errorf("invalid genre ID: %s", id)
 	}
-	genre, err := r.GenreService.GetGenreByID(ctx, uint(uid))
+	genre, err := r.GenreService.GetGenreByID(ctx, uid)
 	if err != nil {
 		return nil, err
 	}
@@ -218,3 +218,16 @@ func (r *Resolver) Query() generated.QueryResolver { return &queryResolver{r} }
 
 type mutationResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
+
+// parseID converts a GraphQL ID string to a uint suitable for database lookups.
+// Using strconv.Atoi (returns int, same word size as uint on every platform) avoids
+// the CodeQL go/incorrect-integer-conversion warning that arises from casting a
+// uint64 (ParseUint result) down to uint on 32-bit systems.
+// This helper lives at the end of the file so gqlgen preserves it on regeneration.
+func parseID(s string) (uint, error) {
+	n, err := strconv.Atoi(s)
+	if err != nil || n <= 0 {
+		return 0, fmt.Errorf("invalid ID: %s", s)
+	}
+	return uint(n), nil
+}


### PR DESCRIPTION
## Summary

Improves the CodeQL integer-conversion fix to be resilient against `go generate` regenerating `schema.resolvers.go`.

## Changes

### `parseID()` helper — survives gqlgen regeneration

The previous fix used `strconv.Atoi` directly in the three resolver functions. While correct, gqlgen's comment states *"any unknown code will be moved to the end"* — so a `parseID()` helper added at the end of the file is preserved on every `go generate` run, while inline changes to resolver bodies are also preserved.

```go
// parseID converts a GraphQL ID string to a uint suitable for database lookups.
// strconv.Atoi returns int (same word size as uint on all platforms), eliminating
// the CodeQL go/incorrect-integer-conversion warning from uint64→uint casting.
func parseID(s string) (uint, error) {
    n, err := strconv.Atoi(s)
    if err != nil || n <= 0 {
        return 0, fmt.Errorf("invalid ID: %s", s)
    }
    return uint(n), nil
}
```

All three affected resolvers (`DeleteAnime`, `Anime`, `Genre`) now call `parseID(id)`.

### `.github/codeql/codeql-config.yml`

Excludes `api/adapters/graphql/generated/**` (100% auto-generated by gqlgen) from CodeQL scanning to reduce noise.

## Test plan

- [x] `go build ./...` clean
- [x] Pre-push hook passed (lint + vet + unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Changes Analysis

### File Type Summary
- **YAML**: 2 files
- **Documentation**: 1 files
- **Go**: 1 files
- **Other**: 4 files

### Detailed Changes

#### YAML Files
- .github/codeql/codeql-config.yml
- .github/workflows/sonar-main.yml

#### Documentation Files
- CHANGELOG.md

#### Go Files
- api/adapters/graphql/schema.resolvers.go

#### Other Files
- frontend/package-lock.json
- frontend/src/components/AnimeCard.tsx
- frontend/src/pages/AnimeDetailPage.tsx
- frontend/src/pages/admin/AdminETLPage.tsx

### Git Statistics

